### PR TITLE
fix: get multiple values for profiel

### DIFF
--- a/internal/idp/providers/ldap/session.go
+++ b/internal/idp/providers/ldap/session.go
@@ -276,7 +276,7 @@ func mapLDAPEntryToUser(
 		phoneVerified,
 		language.Make(user.GetAttributeValue(preferredLanguageAttribute)),
 		user.GetAttributeValue(avatarURLAttribute),
-		user.GetAttributeValue(profileAttribute),
+		user.GetAttributeValues(profileAttribute),
 	), nil
 }
 


### PR DESCRIPTION
# Which Problems Are Solved

Replace this example text with a concise list of problems that this PR solves.
For example:
- If the property XY is not given, the system crashes with a nil pointer exception.

# How the Problems Are Solved

Replace this example text with a concise list of changes that this PR introduces.
For example:
- Validates if property XY is given and throws an error if not

# Additional Changes

Replace this example text with a concise list of additional changes that this PR introduces, that are not directly solving the initial problem but are related.
For example:
- The docs explicitly describe that the property XY is mandatory
- Adds missing translations for validations.

# Additional Context

Replace this example with links to related issues, discussions, discord threads, or other sources with more context.
Use the Closing #issue syntax for issues that are resolved with this PR.
- Closes #xxx
- Discussion #xxx
- Follow-up for PR #xxx
- https://discord.com/channels/xxx/xxx
